### PR TITLE
feat: objects and bulk operations support and moved preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,18 +95,18 @@ MyApp.Knock.client()
 client = MyApp.Knock.client()
 
 # Set preference set for user
-Knock.Preferences.set(client, "jhammond", %{channel_types: %{email: true}})
+Knock.Users.set_preferences(client, "jhammond", %{channel_types: %{email: true}})
 
 # Set granular channel type preferences
-Knock.Preferences.set_channel_type(client, "jhammond", :email, true)
+Knock.Users.set_channel_type_preferences(client, "jhammond", :email, true)
 
 # Set granular workflow preferences
-Knock.Preferences.set_workflow(client, "jhammond", "dinosaurs-loose", %{
+Knock.Users.set_workflow_preferences(client, "jhammond", "dinosaurs-loose", %{
   channel_types: %{email: true}
 })
 
 # Retrieve preferences
-Knock.Preferences.get(client, "jhammond")
+Knock.Users.get_preferences(client, "jhammond")
 ```
 
 ### Getting and setting channel data

--- a/lib/knock/api.ex
+++ b/lib/knock/api.ex
@@ -15,7 +15,7 @@ defmodule Knock.Api do
   @typedoc """
   Defines available options to pass to an API function
   """
-  @type options :: Tesla.option() | []
+  @type options :: [Tesla.option()] | []
 
   @doc """
   Executes a get request against the Knock api.

--- a/lib/knock/resources/bulk_operations.ex
+++ b/lib/knock/resources/bulk_operations.ex
@@ -7,6 +7,7 @@ defmodule Knock.BulkOperations do
   @doc """
   Retrieves the current status of the bulk operation
   """
+  @spec get(Client.t(), String.t()) :: Api.response()
   def get(client, bulk_op_id) do
     Api.get(client, "/bulk_operations/#{bulk_op_id}")
   end

--- a/lib/knock/resources/bulk_operations.ex
+++ b/lib/knock/resources/bulk_operations.ex
@@ -1,0 +1,13 @@
+defmodule Knock.BulkOperations do
+  @moduledoc """
+  Knock resources for accessing Bulk Operations
+  """
+  alias Knock.Api
+
+  @doc """
+  Retrieves the current status of the bulk operation
+  """
+  def get(client, bulk_op_id) do
+    Api.get(client, "/bulk_operations/#{bulk_op_id}")
+  end
+end

--- a/lib/knock/resources/objects.ex
+++ b/lib/knock/resources/objects.ex
@@ -13,11 +13,13 @@ defmodule Knock.Objects do
   @doc """
   Builds an object reference, which can be used in workflow trigger calls.
   """
+  @spec build_ref(String.t(), String.t()) :: ref()
   def build_ref(collection, id), do: %{id: id, collection: collection}
 
   @doc """
-  Sets the given object, performing an upsert operation in the process.
+  Upserts the given object in the collection with the attrs provided.
   """
+  @spec set(Client.t(), String.t(), String.t(), map()) :: Api.response()
   def set(client, collection, id, attrs) do
     Api.put(client, "/objects/#{collection}/#{id}", attrs)
   end
@@ -25,13 +27,15 @@ defmodule Knock.Objects do
   @doc """
   Gets the given object.
   """
+  @spec get(Client.t(), String.t(), String.t()) :: Api.response()
   def get(client, collection, id) do
     Api.get(client, "/objects/#{collection}/#{id}")
   end
 
   @doc """
-  Soft deletes the given object.
+  Deletes the given object.
   """
+  @spec delete(Client.t(), String.t(), String.t()) :: Api.response()
   def delete(client, collection, id) do
     Api.delete(client, "/objects/#{collection}/#{id}")
   end
@@ -41,15 +45,17 @@ defmodule Knock.Objects do
   ##
 
   @doc """
-  Bulk sets one or more objects in a collection
+  Bulk upserts one or more objects in a collection.
   """
-  def bulk_set(client, collection, objects_to_bulk_set) do
-    Api.post(client, "/objects/#{collection}/bulk/set", %{objects: objects_to_bulk_set})
+  @spec bulk_set(Client.t(), String.t(), [map()]) :: Api.response()
+  def bulk_set(client, collection, objects) do
+    Api.post(client, "/objects/#{collection}/bulk/set", %{objects: objects})
   end
 
   @doc """
-  Bulk deletes one or more objects in a collection
+  Bulk deletes one or more objects in a collection.
   """
+  @spec bulk_delete(Client.t(), String.t(), [String.t()]) :: Api.response()
   def bulk_delete(client, collection, object_ids) do
     Api.post(client, "/objects/#{collection}/bulk/delete", %{object_ids: object_ids})
   end

--- a/lib/knock/resources/objects.ex
+++ b/lib/knock/resources/objects.ex
@@ -1,0 +1,78 @@
+defmodule Knock.Objects do
+  @moduledoc """
+  Knock resources for accessing Objects
+  """
+  alias Knock.Api
+  alias Knock.Client
+
+  @typedoc """
+  An object reference is how we refer to a particular object in a collection
+  """
+  @type ref :: %{id: :string, collection: :string}
+
+  @doc """
+  Builds an object reference, which can be used in workflow trigger calls.
+  """
+  def build_ref(collection, id), do: %{id: id, collection: collection}
+
+  @doc """
+  Sets the given object, performing an upsert operation in the process.
+  """
+  def set(client, collection, id, attrs) do
+    Api.put(client, "/objects/#{collection}/#{id}", attrs)
+  end
+
+  @doc """
+  Gets the given object.
+  """
+  def get(client, collection, id) do
+    Api.get(client, "/objects/#{collection}/#{id}")
+  end
+
+  @doc """
+  Soft deletes the given object.
+  """
+  def delete(client, collection, id) do
+    Api.delete(client, "/objects/#{collection}/#{id}")
+  end
+
+  ##
+  # Bulk functions
+  ##
+
+  @doc """
+  Bulk sets one or more objects in a collection
+  """
+  def bulk_set(client, collection, objects_to_bulk_set) do
+    Api.post(client, "/objects/#{collection}/bulk/set", %{objects: objects_to_bulk_set})
+  end
+
+  @doc """
+  Bulk deletes one or more objects in a collection
+  """
+  def bulk_delete(client, collection, object_ids) do
+    Api.post(client, "/objects/#{collection}/bulk/delete", %{object_ids: object_ids})
+  end
+
+  ##
+  # Channel data
+  ##
+
+  @doc """
+  Returns channel data for the given channel id.
+  """
+  @spec get_channel_data(Client.t(), String.t(), String.t(), String.t()) :: Api.response()
+  def get_channel_data(client, collection, id, channel_id) do
+    Api.get(client, "/objects/#{collection}/#{id}/channel_data/#{channel_id}")
+  end
+
+  @doc """
+  Upserts channel data for the given channel id.
+  """
+  @spec set_channel_data(Client.t(), String.t(), String.t(), String.t(), map()) :: Api.response()
+  def set_channel_data(client, collection, id, channel_id, channel_data) do
+    Api.put(client, "/objects/#{collection}/#{id}/channel_data/#{channel_id}", %{
+      data: channel_data
+    })
+  end
+end

--- a/lib/knock/resources/preferences.ex
+++ b/lib/knock/resources/preferences.ex
@@ -1,114 +1,79 @@
 defmodule Knock.Preferences do
   @moduledoc """
-  Knock resources for accessing preferences
+  Knock resources for accessing preferences. Note: this module and all of the functions here are
+  deprecated and will be removed in the next version.
   """
-  alias Knock.Api
-
-  @default_id "default"
+  alias Knock.Users
 
   @doc """
   Returns all of the users preference sets
   """
+  @deprecated "Use Users.get_all_preferences/2 instead"
   def get_all(client, user_id) do
-    Api.get(client, "/users/#{user_id}/preferences")
+    Users.get_all_preferences(client, user_id)
   end
 
   @doc """
   Returns the preference set for the user
   """
+  @deprecated "Use Users.get_preferences/3 instead"
   def get(client, user_id, options \\ []) do
-    preference_set_id = Keyword.get(options, :preference_set, @default_id)
-
-    Api.get(client, "/users/#{user_id}/preferences/#{preference_set_id}")
+    Users.get_preferences(client, user_id, options)
   end
 
   @doc """
   Sets the entire preference set for the user
   """
+  @deprecated "Use Users.set_preferences/4 instead"
   def set(client, user_id, preferences, options \\ []) do
-    preference_set_id = Keyword.get(options, :preference_set, @default_id)
-
-    Api.put(client, "/users/#{user_id}/preferences/#{preference_set_id}", preferences)
+    Users.set_preferences(client, user_id, preferences, options)
   end
 
   @doc """
   Sets the channel type preferences for the user
   """
+  @deprecated "Use Users.set_channel_types_preferences/4 instead"
   def set_channel_types(client, user_id, channel_types, options \\ []) do
-    preference_set_id = Keyword.get(options, :preference_set, @default_id)
-
-    Api.put(
-      client,
-      "/users/#{user_id}/preferences/#{preference_set_id}/channel_types",
-      channel_types
-    )
+    Users.set_channel_types_preferences(client, user_id, channel_types, options)
   end
 
   @doc """
   Sets the channel type preferences for the user
   """
+  @deprecated "Use Users.set_channel_type_preferences/5 instead"
   def set_channel_type(client, user_id, channel_type, setting, options \\ []) do
-    preference_set_id = Keyword.get(options, :preference_set, @default_id)
-
-    Api.put(
-      client,
-      "/users/#{user_id}/preferences/#{preference_set_id}/channel_types/#{channel_type}",
-      %{subscribed: setting}
-    )
+    Users.set_channel_type_preferences(client, user_id, channel_type, setting, options)
   end
 
   @doc """
   Sets the workflow preferences for the user
   """
+  @deprecated "Use Users.set_workflows_preferences/4 instead"
   def set_workflows(client, user_id, workflows, options \\ []) do
-    preference_set_id = Keyword.get(options, :preference_set, @default_id)
-
-    Api.put(
-      client,
-      "/users/#{user_id}/preferences/#{preference_set_id}/workflows",
-      workflows
-    )
+    Users.set_workflows_preferences(client, user_id, workflows, options)
   end
 
   @doc """
   Sets the workflow preference for the user
   """
+  @deprecated "Use Users.set_workflow_preferences/5 instead"
   def set_workflow(client, user_id, workflow_key, setting, options \\ []) do
-    preference_set_id = Keyword.get(options, :preference_set, @default_id)
-
-    Api.put(
-      client,
-      "/users/#{user_id}/preferences/#{preference_set_id}/workflows/#{workflow_key}",
-      build_setting_param(setting)
-    )
+    Users.set_workflow_preferences(client, user_id, workflow_key, setting, options)
   end
 
   @doc """
   Sets the workflow preferences for the user
   """
+  @deprecated "Use Users.set_categories_preferences/4 instead"
   def set_categories(client, user_id, categories, options \\ []) do
-    preference_set_id = Keyword.get(options, :preference_set, @default_id)
-
-    Api.put(
-      client,
-      "/users/#{user_id}/preferences/#{preference_set_id}/categories",
-      categories
-    )
+    Users.set_categories_preferences(client, user_id, categories, options)
   end
 
   @doc """
   Sets the workflow preference for the user
   """
+  @deprecated "Use Users.set_category_preferences/5 instead"
   def set_category(client, user_id, category_key, setting, options \\ []) do
-    preference_set_id = Keyword.get(options, :preference_set, @default_id)
-
-    Api.put(
-      client,
-      "/users/#{user_id}/preferences/#{preference_set_id}/categories/#{category_key}",
-      build_setting_param(setting)
-    )
+    Users.set_category_preferences(client, user_id, category_key, setting, options)
   end
-
-  defp build_setting_param(setting) when is_map(setting), do: setting
-  defp build_setting_param(setting), do: %{subscribed: setting}
 end

--- a/lib/knock/resources/users.ex
+++ b/lib/knock/resources/users.ex
@@ -5,11 +5,22 @@ defmodule Knock.Users do
   alias Knock.Api
   alias Knock.Client
 
+  @default_preference_set_id "default"
+
   @doc """
   Returns information about the user from the `user_id` given.
   """
   @spec get_user(Client.t(), String.t()) :: Api.response()
+  @deprecated "Use get/2 instead"
   def get_user(client, user_id) do
+    get(client, user_id)
+  end
+
+  @doc """
+  Returns information about the user
+  """
+  @spec get(Client.t(), String.t()) :: Api.response()
+  def get(client, user_id) do
     Api.get(client, "/users/#{user_id}")
   end
 
@@ -31,6 +42,38 @@ defmodule Knock.Users do
   end
 
   @doc """
+  Returns a feed for the user with the given channel_id. Optionally supports all of the options
+  for fetching the feed.
+  """
+  def get_feed(client, user_id, channel_id, options \\ []) do
+    query = URI.encode_query(options)
+
+    Api.get(client, "/users/#{user_id}/feeds/#{channel_id}", query: query)
+  end
+
+  ##
+  # Bulk actions
+  ##
+
+  @doc """
+  Bulk identifies the list of users given. Can accept a maximum of 100 users at a time.
+  """
+  def bulk_identify(client, users) do
+    Api.post(client, "/users/bulk/identify", %{users: users})
+  end
+
+  @doc """
+  Bulk deletes the list of users given. Can accept a maximum of 100 users at a time.
+  """
+  def bulk_delete(client, user_ids) do
+    Api.post(client, "/users/bulk/delete", %{user_ids: user_ids})
+  end
+
+  ##
+  # Channel data
+  ##
+
+  @doc """
   Returns user's channel data for the given channel id.
   """
   @spec get_channel_data(Client.t(), String.t(), String.t()) :: Api.response()
@@ -45,4 +88,127 @@ defmodule Knock.Users do
   def set_channel_data(client, user_id, channel_id, channel_data) do
     Api.put(client, "/users/#{user_id}/channel_data/#{channel_id}", %{data: channel_data})
   end
+
+  ##
+  # Preferences
+  ##
+
+  @doc """
+  Returns all of the users preference sets
+  """
+  def get_all_preferences(client, user_id) do
+    Api.get(client, "/users/#{user_id}/preferences")
+  end
+
+  @doc """
+  Returns the preference set for the user
+  """
+  def get_preferences(client, user_id, options \\ []) do
+    preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
+
+    Api.get(client, "/users/#{user_id}/preferences/#{preference_set_id}")
+  end
+
+  @doc """
+  Sets the entire preference set for the user
+  """
+  def set_preferences(client, user_id, preferences, options \\ []) do
+    preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
+
+    Api.put(client, "/users/#{user_id}/preferences/#{preference_set_id}", preferences)
+  end
+
+  @doc """
+  Bulk sets the preferences given for the list of user ids.
+  """
+  def bulk_set_preferences(client, user_ids, preferences, options \\ []) do
+    preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
+    preferences = Map.put_new(preferences, "id", preference_set_id)
+
+    Api.post(client, "/users/bulk/preferences", %{
+      user_ids: user_ids,
+      preferences: preferences
+    })
+  end
+
+  @doc """
+  Sets the channel type preferences for the user
+  """
+  def set_channel_types_preferences(client, user_id, channel_types, options \\ []) do
+    preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
+
+    Api.put(
+      client,
+      "/users/#{user_id}/preferences/#{preference_set_id}/channel_types",
+      channel_types
+    )
+  end
+
+  @doc """
+  Sets the channel type preferences for the user
+  """
+  def set_channel_type_preferences(client, user_id, channel_type, setting, options \\ []) do
+    preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
+
+    Api.put(
+      client,
+      "/users/#{user_id}/preferences/#{preference_set_id}/channel_types/#{channel_type}",
+      %{subscribed: setting}
+    )
+  end
+
+  @doc """
+  Sets the workflow preferences for the user
+  """
+  def set_workflows_preferences(client, user_id, workflows, options \\ []) do
+    preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
+
+    Api.put(
+      client,
+      "/users/#{user_id}/preferences/#{preference_set_id}/workflows",
+      workflows
+    )
+  end
+
+  @doc """
+  Sets the workflow preference for the user
+  """
+  def set_workflow_preferences(client, user_id, workflow_key, setting, options \\ []) do
+    preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
+
+    Api.put(
+      client,
+      "/users/#{user_id}/preferences/#{preference_set_id}/workflows/#{workflow_key}",
+      build_setting_param(setting)
+    )
+  end
+
+  @doc """
+  Sets the workflow preferences for the user
+  """
+  def set_categories_preferences(client, user_id, categories, options \\ []) do
+    preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
+
+    Api.put(
+      client,
+      "/users/#{user_id}/preferences/#{preference_set_id}/categories",
+      categories
+    )
+  end
+
+  @doc """
+  Sets the workflow preference for the user
+  """
+  def set_category_preferences(client, user_id, category_key, setting, options \\ []) do
+    preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
+
+    Api.put(
+      client,
+      "/users/#{user_id}/preferences/#{preference_set_id}/categories/#{category_key}",
+      build_setting_param(setting)
+    )
+  end
+
+  defp build_setting_param(setting) when is_map(setting), do: setting
+  defp build_setting_param(setting), do: %{subscribed: setting}
 end

--- a/lib/knock/resources/users.ex
+++ b/lib/knock/resources/users.ex
@@ -17,7 +17,7 @@ defmodule Knock.Users do
   end
 
   @doc """
-  Returns information about the user
+  Returns information about the user.
   """
   @spec get(Client.t(), String.t()) :: Api.response()
   def get(client, user_id) do
@@ -25,8 +25,7 @@ defmodule Knock.Users do
   end
 
   @doc """
-  Sets the given properties on the user specified via the `user_id`. Will perform
-  an upsert of the user.
+  Upserts the user specified via the `user_id` with the given properties.
   """
   @spec identify(Client.t(), String.t(), map()) :: Api.response()
   def identify(client, user_id, properties) do
@@ -45,6 +44,7 @@ defmodule Knock.Users do
   Returns a feed for the user with the given channel_id. Optionally supports all of the options
   for fetching the feed.
   """
+  @spec get_feed(Client.t(), String.t(), String.t(), Keyword.t()) :: Api.response()
   def get_feed(client, user_id, channel_id, options \\ []) do
     query = URI.encode_query(options)
 
@@ -58,6 +58,7 @@ defmodule Knock.Users do
   @doc """
   Bulk identifies the list of users given. Can accept a maximum of 100 users at a time.
   """
+  @spec bulk_identify(Client.t(), [map()]) :: Api.response()
   def bulk_identify(client, users) do
     Api.post(client, "/users/bulk/identify", %{users: users})
   end
@@ -65,6 +66,7 @@ defmodule Knock.Users do
   @doc """
   Bulk deletes the list of users given. Can accept a maximum of 100 users at a time.
   """
+  @spec bulk_delete(Client.t(), [String.t()]) :: Api.response()
   def bulk_delete(client, user_ids) do
     Api.post(client, "/users/bulk/delete", %{user_ids: user_ids})
   end
@@ -96,13 +98,15 @@ defmodule Knock.Users do
   @doc """
   Returns all of the users preference sets
   """
+  @spec get_all_preferences(Client.t(), String.t()) :: Api.response()
   def get_all_preferences(client, user_id) do
     Api.get(client, "/users/#{user_id}/preferences")
   end
 
   @doc """
-  Returns the preference set for the user
+  Returns the preference set for the user.
   """
+  @spec get_preferences(Client.t(), String.t(), Keyword.t()) :: Api.response()
   def get_preferences(client, user_id, options \\ []) do
     preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
 
@@ -110,8 +114,9 @@ defmodule Knock.Users do
   end
 
   @doc """
-  Sets the entire preference set for the user
+  Sets an entire preference set for the user. Will overwrite any existing data.
   """
+  @spec set_preferences(Client.t(), String.t(), map(), Keyword.t()) :: Api.response()
   def set_preferences(client, user_id, preferences, options \\ []) do
     preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
 
@@ -119,8 +124,10 @@ defmodule Knock.Users do
   end
 
   @doc """
-  Bulk sets the preferences given for the list of user ids.
+  Bulk sets the preferences given for the list of user ids. Will overwrite the any existing
+  preferences for these users.
   """
+  @spec bulk_set_preferences(Client.t(), [String.t()], map(), Keyword.t()) :: Api.response()
   def bulk_set_preferences(client, user_ids, preferences, options \\ []) do
     preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
     preferences = Map.put_new(preferences, "id", preference_set_id)
@@ -132,8 +139,10 @@ defmodule Knock.Users do
   end
 
   @doc """
-  Sets the channel type preferences for the user
+  Sets the channel type preferences for the user.
   """
+  @spec set_channel_types_preferences(Client.t(), String.t(), map(), Keyword.t()) ::
+          Api.response()
   def set_channel_types_preferences(client, user_id, channel_types, options \\ []) do
     preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
 
@@ -145,8 +154,10 @@ defmodule Knock.Users do
   end
 
   @doc """
-  Sets the channel type preferences for the user
+  Sets the channel type preference for the user.
   """
+  @spec set_channel_type_preferences(Client.t(), String.t(), String.t(), boolean(), Keyword.t()) ::
+          Api.response()
   def set_channel_type_preferences(client, user_id, channel_type, setting, options \\ []) do
     preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
 
@@ -158,8 +169,9 @@ defmodule Knock.Users do
   end
 
   @doc """
-  Sets the workflow preferences for the user
+  Sets the workflow preferences for the user.
   """
+  @spec set_workflows_preferences(Client.t(), String.t(), map(), Keyword.t()) :: Api.response()
   def set_workflows_preferences(client, user_id, workflows, options \\ []) do
     preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
 
@@ -171,8 +183,15 @@ defmodule Knock.Users do
   end
 
   @doc """
-  Sets the workflow preference for the user
+  Sets the workflow preference for the user.
   """
+  @spec set_workflow_preferences(
+          Client.t(),
+          String.t(),
+          String.t(),
+          map() | boolean(),
+          Keyword.t()
+        ) :: Api.response()
   def set_workflow_preferences(client, user_id, workflow_key, setting, options \\ []) do
     preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
 
@@ -184,8 +203,9 @@ defmodule Knock.Users do
   end
 
   @doc """
-  Sets the workflow preferences for the user
+  Sets the category preferences for the user.
   """
+  @spec set_categories_preferences(Client.t(), String.t(), map(), Keyword.t()) :: Api.response()
   def set_categories_preferences(client, user_id, categories, options \\ []) do
     preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
 
@@ -197,8 +217,15 @@ defmodule Knock.Users do
   end
 
   @doc """
-  Sets the workflow preference for the user
+  Sets the category preference for the user.
   """
+  @spec set_category_preferences(
+          Client.t(),
+          String.t(),
+          String.t(),
+          map() | boolean(),
+          Keyword.t()
+        ) :: Api.response()
   def set_category_preferences(client, user_id, category_key, setting, options \\ []) do
     preference_set_id = Keyword.get(options, :preference_set, @default_preference_set_id)
 

--- a/lib/knock/resources/workflows.ex
+++ b/lib/knock/resources/workflows.ex
@@ -19,7 +19,7 @@ defmodule Knock.Workflows do
 
   Can optionally be provided with:
 
-  - `recipients`: A list of user ids to cancel the notify for
+  - `recipients`: A list of recipients to cancel the notify for
   """
   @spec cancel(Knock.Client.t(), String.t(), String.t(), map()) :: Api.response()
   def cancel(client, key, cancellation_key, properties \\ %{}) do


### PR DESCRIPTION
* Adds `Knock.Objects` namespace
* Adds new bulk operations for `Knock.Users` (`bulk_identify`, `bulk_delete`)
* Deprecates the existing `Knock.Preferences` module in favor or user specific preference functions
* Adds new `Knock.Users.bulk_set_preferences/3` function
* Adds new `Knock.BulkOperations.get` function
* Adds new `Knock.Users.get_feed/3` function 