### PR TITLE
feat(kno-2628): add trigger_data param support

### DIFF
--- a/lib/knock/resources/messages.ex
+++ b/lib/knock/resources/messages.ex
@@ -2,6 +2,8 @@ defmodule Knock.Messages do
   @moduledoc """
   Knock resources for accessing messages
   """
+  import Knock.ResourceHelpers, only: [maybe_json_encode_param: 2]
+
   alias Knock.Api
   alias Knock.Client
 
@@ -17,10 +19,13 @@ defmodule Knock.Messages do
   # - tenant: tenant_id to filter messages with
   # - channel_id: channel_id to filter messages with
   # - source: workflow key to filter messages with
+  # - trigger_data: trigger payload to filter messages with
 
   """
   @spec list(Client.t(), Keyword.t()) :: Api.response()
   def list(client, options \\ []) do
+    options = maybe_json_encode_param(options, :trigger_data)
+
     Api.get(client, "/messages", query: options)
   end
 
@@ -48,9 +53,12 @@ defmodule Knock.Messages do
   # - page_size: specify size of the page to be returned by the api. (max limit: 50)
   # - after:  after cursor for pagination
   # - before: before cursor for pagination
+  # - trigger_data: filter activities by trigger payload data
   """
   @spec get_activities(Client.t(), String.t(), Keyword.t()) :: Api.response()
   def get_activities(client, message_id, options \\ []) do
+    options = maybe_json_encode_param(options, :trigger_data)
+
     Api.get(client, "/messages/#{message_id}/activities", query: options)
   end
 

--- a/lib/knock/resources/objects.ex
+++ b/lib/knock/resources/objects.ex
@@ -2,6 +2,8 @@ defmodule Knock.Objects do
   @moduledoc """
   Knock resources for accessing Objects
   """
+  import Knock.ResourceHelpers, only: [maybe_json_encode_param: 2]
+
   alias Knock.Api
   alias Knock.Client
 
@@ -107,9 +109,12 @@ defmodule Knock.Objects do
   # - tenant: tenant_id to filter messages with
   # - channel_id: channel_id to filter messages with
   # - source: workflow key to filter messages with
+  # - trigger_data: trigger payload to filter messages with
   """
   @spec get_messages(Client.t(), String.t(), String.t(), Keyword.t()) :: Api.response()
   def get_messages(client, collection, id, options \\ []) do
+    options = maybe_json_encode_param(options, :trigger_data)
+
     Api.get(client, "/objects/#{collection}/#{id}/messages", query: options)
   end
 

--- a/lib/knock/resources/resource_helpers.ex
+++ b/lib/knock/resources/resource_helpers.ex
@@ -1,0 +1,20 @@
+defmodule Knock.ResourceHelpers do
+  @doc """
+  Helpers for building resources API requests
+  """
+
+  @spec maybe_json_encode_param(Keyword.t(), String.t()) :: Keyword.t()
+  def maybe_json_encode_param(options, param_key) do
+    case options[param_key] do
+      param when is_map(param) ->
+        encoded_param = Jason.encode!(param)
+        Keyword.put(options, param_key, encoded_param)
+
+      param when is_nil(param) ->
+        options
+
+      _ ->
+        raise "Incorrect #{param_key} type, expected map"
+    end
+  end
+end

--- a/lib/knock/resources/users.ex
+++ b/lib/knock/resources/users.ex
@@ -2,6 +2,8 @@ defmodule Knock.Users do
   @moduledoc """
   Knock resources for accessing users
   """
+  import Knock.ResourceHelpers, only: [maybe_json_encode_param: 2]
+
   alias Knock.Api
   alias Knock.Client
 
@@ -43,9 +45,22 @@ defmodule Knock.Users do
   @doc """
   Returns a feed for the user with the given channel_id. Optionally supports all of the options
   for fetching the feed.
+
+  # Available optional parameters:
+  #
+  # - page_size: specify size of the page to be returned by the api. (max limit: 50)
+  # - after:  after cursor for pagination
+  # - before: before cursor for pagination
+  # - status: list of statuses to filter feed items with
+  # - tenant: tenant_id to filter messages with
+  # - has_tenant: optionally scope items by a tenant id or no tenant
+  # - archived: scope items by a given archived status (defaults to "exclude")
+  # - trigger_data: trigger payload to filter feed items with
   """
   @spec get_feed(Client.t(), String.t(), String.t(), Keyword.t()) :: Api.response()
   def get_feed(client, user_id, channel_id, options \\ []) do
+    options = maybe_json_encode_param(options, :trigger_data)
+
     Api.get(client, "/users/#{user_id}/feeds/#{channel_id}", query: options)
   end
 
@@ -266,9 +281,12 @@ defmodule Knock.Users do
   # - tenant: tenant_id to filter messages with
   # - channel_id: channel_id to filter messages with
   # - source: workflow key to filter messages with
+  # - trigger_data: trigger payload to filter messages with
   """
   @spec get_messages(Client.t(), String.t(), Keyword.t()) :: Api.response()
   def get_messages(client, id, options \\ []) do
+    options = maybe_json_encode_param(options, :trigger_data)
+
     Api.get(client, "/users/#{id}/messages", query: options)
   end
 


### PR DESCRIPTION
Add support for the `trigger_data` param on the following endpoints:

* Messages list
* Message activities
* User messages
* Object messages
* User feed