### PR TITLE
feat(kno-3590): add message status update endpoints

### DIFF
--- a/lib/knock/resources/channels.ex
+++ b/lib/knock/resources/channels.ex
@@ -1,0 +1,29 @@
+defmodule Knock.Channels do
+  @moduledoc """
+  Knock resources for accessing channels
+  """
+
+  alias Knock.Api
+  alias Knock.Client
+
+  @doc """
+  Bulk updates channel's messages with provided action.
+  Supports filtering messages to be updated with the following options:
+
+  - tenants: Scope messages to the list of tenant ids
+  - has_tenant: Scope to where either do or do not have a tenant present
+  - recipient_ids: Scope messages to the list of recipient ids
+  - engagement_status: Scope messages by engagements status: read, unread, seen,
+    unseen, archived, unarchived, interacted, link_clicked
+  - archived: scopes to a particular type of archival status, one of
+    exclude, include, only
+  - delivery_status: scope to only messages by delivery status, these can be the following:
+    queued, sent, undelivered, delivery_attempted, delivered
+  - older_than: scope to only messages that were created before provided date
+  - newer_than: scope to only messages that were created after provided date
+  """
+  @spec bulk_set_messages_status(Client.t(), String.t(), String.t(), map()) :: Api.response()
+  def bulk_set_messages_status(client, channel_id, action, filtering_options \\ %{}) do
+    Api.post(client, "/channels/#{channel_id}/messages/bulk/#{action}", filtering_options)
+  end
+end

--- a/lib/knock/resources/messages.ex
+++ b/lib/knock/resources/messages.ex
@@ -38,6 +38,31 @@ defmodule Knock.Messages do
   end
 
   @doc """
+  Sets status of message: seen, read, archived
+  """
+  @spec set_status(Client.t(), String.t(), String.t()) :: Api.response()
+  def set_status(client, message_id, status) do
+    Api.put(client, "/messages/#{message_id}/#{status}", %{})
+  end
+
+  @doc """
+  Unsets status of message: unseen, unread, unarchived
+  """
+  @spec unset_status(Client.t(), String.t(), String.t()) :: Api.response()
+  def unset_status(client, message_id, status) do
+    Api.delete(client, "/messages/#{message_id}/#{status}")
+  end
+
+  @doc """
+  Batch update messages statuses: seen, read, interacted, archived, unseen, unread,
+  unarchived
+  """
+  @spec batch_set_status(Client.t(), [String.t()], String.t()) :: Api.response()
+  def batch_set_status(client, message_ids, status) do
+    Api.post(client, "/messages/batch/#{status}", %{message_ids: message_ids})
+  end
+
+  @doc """
   Returns information about the message content.
   """
   @spec get_content(Client.t(), String.t()) :: Api.response()


### PR DESCRIPTION
Support for:

* PUT /v1/messages/:id/:status
* DELETE /v1/messages/:id/:status
* POST /v1/messages/batch/:status
* POST /v1/channels/:id/messages/bulk/:status