### PR TITLE
feat(kno-3746): add subscription endpoints support

### DIFF
--- a/lib/knock/resources/objects.ex
+++ b/lib/knock/resources/objects.ex
@@ -202,12 +202,15 @@ defmodule Knock.Objects do
 
   Expected properties:
   - recipients: list of recipients to create subscriptions for
-  - properties: data to be stored at the subscription level for each recipient
   """
   @spec delete_subscriptions(Client.t(), String.t(), String.t(), [String.t() | map()]) ::
           Api.response()
-  def delete_subscriptions(client, collection, id, recipients) do
-    Api.post(client, "/objects/#{collection}/#{id}/subscriptions", %{recipients: recipients})
+  def delete_subscriptions(client, collection, id, params) do
+    recipients = Map.get(params, :recipients)
+
+    Api.delete(client, "/objects/#{collection}/#{id}/subscriptions",
+      body: %{recipients: recipients}
+    )
   end
 
   ##

--- a/lib/knock/resources/objects.ex
+++ b/lib/knock/resources/objects.ex
@@ -17,8 +17,6 @@ defmodule Knock.Objects do
 
   # Available optional parameters:
   #
-  # - name: return object instances with matching name property
-  # - object_id: returns object by matching object id
   # - page_size: specify size of the page to be returned by the api. (max limit: 50)
   # - after:  after cursor for pagination
   # - before: before cursor for pagination

--- a/lib/knock/resources/objects.ex
+++ b/lib/knock/resources/objects.ex
@@ -17,6 +17,8 @@ defmodule Knock.Objects do
 
   # Available optional parameters:
   #
+  # - name: return object instances with matching name property
+  # - object_id: returns object by matching object id
   # - page_size: specify size of the page to be returned by the api. (max limit: 50)
   # - after:  after cursor for pagination
   # - before: before cursor for pagination
@@ -150,6 +152,64 @@ defmodule Knock.Objects do
   @spec get_schedules(Client.t(), String.t(), String.t(), Keyword.t()) :: Api.response()
   def get_schedules(client, collection, id, options \\ []) do
     Api.get(client, "/objects/#{collection}/#{id}/schedules", query: options)
+  end
+
+  ##
+  # Subscriptions
+  ##
+
+  @doc """
+  Returns paginated subscriptions for the given object
+
+  # Available optional parameters:
+  #
+  # - page_size: specify size of the page to be returned by the api. (max limit: 50)
+  # - after:  after cursor for pagination
+  # - before: before cursor for pagination
+  """
+  @spec list_subscriptions(Client.t(), String.t(), String.t(), Keyword.t()) :: Api.response()
+  def list_subscriptions(client, collection, id, options \\ []) do
+    Api.get(client, "/objects/#{collection}/#{id}/subscriptions", query: options)
+  end
+
+  @doc """
+  Returns paginated subscriptions for the given object as recipient
+
+  # Available optional parameters:
+  #
+  # - page_size: specify size of the page to be returned by the api. (max limit: 50)
+  # - after:  after cursor for pagination
+  # - before: before cursor for pagination
+  """
+  @spec get_subscriptions(Client.t(), String.t(), String.t(), Keyword.t()) :: Api.response()
+  def get_subscriptions(client, collection, id, options \\ []) do
+    options = Keyword.put(options, :mode, "recipient")
+    Api.get(client, "/objects/#{collection}/#{id}/subscriptions", query: options)
+  end
+
+  @doc """
+  Adds subscriptions for all recipients passed as arguments
+
+  Expected properties:
+  - recipients: list of recipients to create subscriptions for
+  - properties: data to be stored at the subscription level for each recipient
+  """
+  @spec add_subscriptions(Client.t(), String.t(), String.t(), map()) :: Api.response()
+  def add_subscriptions(client, collection, id, params) do
+    Api.post(client, "/objects/#{collection}/#{id}/subscriptions", params)
+  end
+
+  @doc """
+  Delete subscriptions for recipients passed as arguments
+
+  Expected properties:
+  - recipients: list of recipients to create subscriptions for
+  - properties: data to be stored at the subscription level for each recipient
+  """
+  @spec delete_subscriptions(Client.t(), String.t(), String.t(), [String.t() | map()]) ::
+          Api.response()
+  def delete_subscriptions(client, collection, id, recipients) do
+    Api.post(client, "/objects/#{collection}/#{id}/subscriptions", %{recipients: recipients})
   end
 
   ##

--- a/lib/knock/resources/objects.ex
+++ b/lib/knock/resources/objects.ex
@@ -13,6 +13,20 @@ defmodule Knock.Objects do
   @type ref :: %{id: :string, collection: :string}
 
   @doc """
+  Returns paginated list of objects for a collection
+
+  # Available optional parameters:
+  #
+  # - page_size: specify size of the page to be returned by the api. (max limit: 50)
+  # - after:  after cursor for pagination
+  # - before: before cursor for pagination
+  """
+  @spec list(Client.t(), String.t(), Keyword.t()) :: Api.response()
+  def list(client, collection, options \\ []) do
+    Api.get(client, "/objects/#{collection}", query: options)
+  end
+
+  @doc """
   Builds an object reference, which can be used in workflow trigger calls.
   """
   @spec build_ref(String.t(), String.t()) :: ref()

--- a/lib/knock/resources/users.ex
+++ b/lib/knock/resources/users.ex
@@ -14,6 +14,9 @@ defmodule Knock.Users do
 
   # Available optional parameters:
   #
+  # - name: return user instances with matching name property
+  # - email: returns user instances with matching email property
+  # - user_id: returns user by matching user id
   # - page_size: specify size of the page to be returned by the api. (max limit: 50)
   # - after:  after cursor for pagination
   # - before: before cursor for pagination
@@ -322,6 +325,24 @@ defmodule Knock.Users do
   @spec get_schedules(Client.t(), String.t(), Keyword.t()) :: Api.response()
   def get_schedules(client, id, options \\ []) do
     Api.get(client, "/users/#{id}/schedules", query: options)
+  end
+
+  ##
+  # Subscriptions
+  ##
+
+  @doc """
+  Returns paginated subscriptions for the given user
+
+  # Available optional parameters:
+  #
+  # - page_size: specify size of the page to be returned by the api. (max limit: 50)
+  # - after:  after cursor for pagination
+  # - before: before cursor for pagination
+  """
+  @spec get_subscriptions(Client.t(), String.t(), Keyword.t()) :: Api.response()
+  def get_subscriptions(client, id, options \\ []) do
+    Api.get(client, "/users/#{id}/subscriptions", query: options)
   end
 
   defp build_setting_param(setting) when is_map(setting), do: setting

--- a/lib/knock/resources/users.ex
+++ b/lib/knock/resources/users.ex
@@ -14,9 +14,6 @@ defmodule Knock.Users do
 
   # Available optional parameters:
   #
-  # - name: return user instances with matching name property
-  # - email: returns user instances with matching email property
-  # - user_id: returns user by matching user id
   # - page_size: specify size of the page to be returned by the api. (max limit: 50)
   # - after:  after cursor for pagination
   # - before: before cursor for pagination

--- a/lib/knock/resources/users.ex
+++ b/lib/knock/resources/users.ex
@@ -10,6 +10,20 @@ defmodule Knock.Users do
   @default_preference_set_id "default"
 
   @doc """
+  Returns paginated list of users
+
+  # Available optional parameters:
+  #
+  # - page_size: specify size of the page to be returned by the api. (max limit: 50)
+  # - after:  after cursor for pagination
+  # - before: before cursor for pagination
+  """
+  @spec list(Client.t(), Keyword.t()) :: Api.response()
+  def list(client, options \\ []) do
+    Api.get(client, "/users", query: options)
+  end
+
+  @doc """
   Returns information about the user from the `user_id` given.
   """
   @spec get_user(Client.t(), String.t()) :: Api.response()


### PR DESCRIPTION
Adds support for subscription endpoints:
* Add subscriptions to objects
* Delete subscriptions
* List subscription for object
* Get subscriptions for object as recipient
* Get subscriptions for user

Also adds missing support for:
* List users for environment
* List objects by collection for environment