### PR TITLE
Update signing example with valid System.time_unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ claims = %{
   # When the token was issued
   "iat" => DateTime.to_unix(now),
   # When the token expires (1 hour)
-  "exp" => DateTime.add(now, 3600, :seconds) |> DateTime.to_unix()
+  "exp" => DateTime.add(now, 3600, :second) |> DateTime.to_unix()
 }
 
 


### PR DESCRIPTION
I was running through the tutorial and wiring up an example of the in-app notifications. When I hit the signing section I copy/pasted the example code from the README and got an error:
```
 ** (ArgumentError) unsupported time unit. Expected :day, :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got :seconds
        (elixir 1.15.7) lib/calendar/datetime.ex:1621: DateTime.add/4

... TRUNCATED...
```

This PR adjusts the DateTime parameter in the docs to `:second` which is accepted by the `add` function.