### PR TITLE
chore: allow tesla and hackney minor version bumps

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,8 +29,8 @@ defmodule Knock.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:tesla, "~> 1.4.1"},
-      {:hackney, "~> 1.18.0"},
+      {:tesla, "~> 1.4"},
+      {:hackney, "~> 1.18"},
       {:jason, "~> 1.1"},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false}
     ]


### PR DESCRIPTION
This relaxes the version requirements to allow for minor version differences. 
Similar to #23 but also relaxes `hackney` and doesn't bump the tesla version.

This avoid having to override on our dep configurations.
