### PR TITLE
Add ability to modify middleware via a configured callback. #14 

### DIFF
--- a/lib/knock.ex
+++ b/lib/knock.ex
@@ -46,7 +46,8 @@ defmodule Knock do
   ```elixir
   config :my_app, Knock,
     adapter: Tesla.Adapter.Finch,
-    json_client: JSX
+    json_client: JSX,
+    middleware_callback: & [ Tesla.Middleware.OpenTelemetry | &1]
   ```
 
   You can read more about the availble adapters in the [Tesla documentation](https://hexdocs.pm/tesla/readme.html#adapters)

--- a/lib/knock/api.ex
+++ b/lib/knock/api.ex
@@ -88,6 +88,8 @@ defmodule Knock.Api do
        ] ++ maybe_idempotency_key_header(Map.new(opts))}
     ]
 
+    middleware = (config.middleware_callback || & &1).(middleware)
+
     Tesla.client(middleware, config.adapter)
   end
 

--- a/lib/knock/client.ex
+++ b/lib/knock/client.ex
@@ -14,7 +14,8 @@ defmodule Knock.Client do
   defstruct host: "https://api.knock.app",
             api_key: nil,
             adapter: Tesla.Adapter.Hackney,
-            json_client: Jason
+            json_client: Jason,
+            middleware_callback: nil
 
   @typedoc """
   Describes a Knock client
@@ -23,7 +24,8 @@ defmodule Knock.Client do
           host: String.t(),
           api_key: String.t(),
           adapter: atom(),
-          json_client: atom()
+          json_client: atom(),
+          middleware_callback: ([atom()] -> [atom()])
         }
 
   @doc """
@@ -36,7 +38,7 @@ defmodule Knock.Client do
       raise Knock.ApiKeyMissingError
     end
 
-    opts = Keyword.take(opts, [:host, :api_key, :adapter, :json_client])
+    opts = Keyword.take(opts, [:host, :api_key, :adapter, :json_client, :middleware_callback])
     struct!(__MODULE__, opts)
   end
 end


### PR DESCRIPTION
This allows dynamic configuration of the middleware passed to the Tesla client.  If no `middleware_callback` is configured, the middleware is passed to the callback, and may be modified as needed.  

This resolves #14 

Usage for open telemetry middleware:
```
config :my_app, MyApp.KnockImpl,
       api_key: System.get_env("KNOCK_API_PRIVATE_KEY"),
       middleware_callback: & [ Tesla.Middleware.OpenTelemetry | &1]
```